### PR TITLE
Improved docker setup

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,0 +1,57 @@
+name: Publish Docker Images
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Setup Java and Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+
+      - name: Run sbt docker stage
+        run: sbt docker:stage
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push amm-executor image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./modules/amm-executor/target/docker/stage
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: spectrumlabs/ergo-amm-executor:latest
+
+      - name: Build and push utxo-tracker image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./modules/utxo-tracker/target/docker/stage
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: spectrumlabs/ergo-utxo-tracker:latest
+
+      - name: Build and push pool-resolver image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./modules/pool-resolver/target/docker/stage
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: spectrumlabs/ergo-pool-resolver:latest

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The services require access to an Ergo node, so if you do not have one yet insta
 Besides the node the services depend on tools such as Kafka and Redis to run, to make it easier to manage a docker based solution has been made to allow for easy building and running of the services.
 The only requirements besides the node are that you have the following installed:
  - GIT to download the code and help fetch updates. [GIT](https://git-scm.com/)
- - SBT (which requires Java) for building the bots. [SBT](https://www.scala-sbt.org/index.html)
  - Docker and Docker-compose (included in Docker for Windows). [Docker](https://www.docker.com/get-started)
 
 ### Building
@@ -31,21 +30,30 @@ First you need to download the code from this repo. The easiest way to keep it u
 cd <the folder you want to keep the off-chain services code in>
 git clone https://github.com/ergolabs/ergo-dex-backend.git
 ```
-Instructions for building the services are all combined in the build script and the docker-compose.yml file. The only configuration needed for running the services need to be stored in a file called config.env. An example can be found in config-example.env
+Instructions for the containers are all defined in the `docker-compose.yml` file. The only configuration needed for running the services need to be stored in a file called config.env. An example can be found in `config-example.env`
 Make a copy of the example file, name it config.env and edit the file to match your values:
+
+Linux:
 ```
 cd ergo-dex-backend
 cp ./config-example.env ./config.env
 ```
-The 2 values that need to be changed in the config.env file are the address you want to recieve fees on and the URI to your node (localhost/127.0.0.1 might not be accessible from within a docker container, it is best to use the local lan ip if the node is running on the same host).
-Finally the Docker images need to be build before running them:
+Windows:
 ```
-./build
+cd ergo-dex-backend
+copy ./config-example.env ./config.env
 ```
+The 2 values that need to be changed in the `config.env` file are the address you want to recieve fees on and the URI to your node (localhost/127.0.0.1 might not be accessible from within a docker container, it is best to use the local lan ip if the node is running on the same host).
 ### Running the services
-Once the Docker images are built the only thing left to do is to run them:
+Once the `config.env` file is created the only thing left to do is to run the containers:
+
+Linux:
 ```
-./run
+sudo -E docker-compose up -d
+```
+Windows:
+```
+docker compose up -d
 ```
 #### Verifying the services are running correctly
 You can look into the logs of the services to ensure they are running correctly. To look at a combined log for all services use the following command:
@@ -58,4 +66,20 @@ Linux:
 ```
 cd ergo-dex-backend
 sudo docker-compose logs -f
+```
+
+### Updating the services
+After running `git pull` from the instructions below make sure to check for potential changes in `config-example.env` to apply to your own `config.env`!
+
+Linux:
+```
+git pull
+sudo -E docker-compose pull
+sudo -E docker-compose up -d
+```
+Windows:
+```
+git pull
+docker-compose pull
+docker-compose up -d
 ```

--- a/build
+++ b/build
@@ -1,6 +1,0 @@
-mkdir -m 777 -p ../data/pool-resolver/rocks
-git pull
-git checkout $1
-sudo -E sbt docker:stage
-export DEX_SOURCES_PATH=${PWD}
-sudo -E docker-compose build $2

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,0 @@
-git pull
-git checkout $1
-sbt docker:stage
-$env:DEX_SOURCES_PATH=$PSScriptRoot
-docker compose build $2

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ def nativePackagerSettings(moduleSig: String) = List(
   Universal / mappings += ((Compile / packageBin) map { p =>
     p -> s"lib/$moduleSig.jar"
   }).value,
-  dockerExposedVolumes := Seq(s"/var/lib/$moduleSig", "/opt/docker/logs/")
+  dockerExposedVolumes := Seq(s"/var/lib/$moduleSig", "/var/log/dex-backend")
 )
 
 lazy val commonScalacOptions = List(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,81 +1,100 @@
 version: '3'
 services:
-  zoo1:
-    image: zookeeper:3.4.9
-    hostname: zoo1
-    environment:
-      ZOO_MY_ID: 1
-      ZOO_PORT: 2181
-      ZOO_SERVERS: server.1=zoo1:2888:3888
-    volumes:
-      - "../zk-kafka/zoo1/data:/data:rw"
-      - "../zk-kafka/zoo1/datalog:/datalog:rw"
-  kafka1:
-    image: confluentinc/cp-kafka:5.3.0
-    hostname: kafka1
-    container_name: kafka1
-    links:
-      - zoo1
-    environment:
-      HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
-      KAFKA_BROKER_ID: 1
-      KAFKA_REPLICATION_FACTOR: 1
-      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
-      KAFKA_ZOOKEEPER_CONNECT: "zoo1:2181"
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka1:9092,CONNECTIONS_FROM_HOST://localhost:19091
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONNECTIONS_FROM_HOST:PLAINTEXT
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-    volumes:
-      - "../zk-kafka/kafka1/data:/var/lib/kafka/data:rw"
-  manager:
-    image: sheepkiller/kafka-manager
-    ports:
-      - 9000:9000
-    environment:
-      - ZK_HOSTS=zoo1:2181
-    depends_on:
-      - zoo1
-  redis:
-    image: redis:latest
+  zookeeper:
+    image: zookeeper:3.7
+    container_name: zookeeper
     restart: always
-    command: ["redis-server"]
+    environment:
+      ALLOW_ANONYMOUS_LOGIN: "yes"
+      ZOO_ADMINSERVER_ENABLED: "false"
+    volumes:
+      - "zookeeper-data:/data"
+      - "zookeeper-datalog:/datalog"
+    networks:
+      - spectrum-network
+  kafka:
+    image: bitnami/kafka:2
+    container_name: kafka
+    restart: always
+    environment:
+      KAFKA_BROKER_ID: "1"
+      KAFKA_CFG_LISTENERS: "PLAINTEXT://:9092"
+      KAFKA_CFG_ADVERTISED_LISTENERS: "PLAINTEXT://kafka:9092"
+      KAFKA_CFG_ZOOKEEPER_CONNECT: zookeeper:2181
+      ALLOW_PLAINTEXT_LISTENER: "yes"
+    volumes:
+      - "kafka-data:/bitnami/kafka"
+    depends_on:
+      - zookeeper
+    networks:
+      - spectrum-network
+  redis:
+    image: redis:7.0-alpine
+    container_name: redis
+    restart: always
     ports:
-      - "127.0.0.1:6379:6379"
+      - "6379:6379"
     volumes:
-      - "../redis:/data"
-  tracker:
+      - "redis-data:/data"
+    networks:
+      - spectrum-network
+  utxo-tracker:
     build:
-      context: ${DEX_SOURCES_PATH}/modules/utxo-tracker/target/docker/stage
+      context: ./modules/utxo-tracker/target/docker/stage
       dockerfile: Dockerfile
+    container_name: utxo-tracker
     volumes:
-      - "../logs:/var/log/dex-backend:rw"
+      - "log-data:/var/log/dex-backend"
     env_file: config.env
     depends_on:
-      - kafka1
+      - kafka
       - redis
+    networks:
+      - spectrum-network
   amm-executor:
     build:
-      context: ${DEX_SOURCES_PATH}/modules/amm-executor/target/docker/stage
+      context: ./modules/amm-executor/target/docker/stage
       dockerfile: Dockerfile
+    container_name: amm-executor
+    restart: always
     volumes:
-      - "../logs:/var/log/dex-backend:rw"
+      - "log-data:/var/log/dex-backend"
     env_file: config.env
     depends_on:
-      - kafka1
+      - kafka
       - poolresolver
+    networks:
+      - spectrum-network
   poolresolver:
     build:
-      context: ${DEX_SOURCES_PATH}/modules/pool-resolver/target/docker/stage
+      context: ./modules/pool-resolver/target/docker/stage
       dockerfile: Dockerfile
+    container_name: poolresolver
     volumes:
-      - "../logs:/var/log/dex-backend:rw"
-      - "../data/pool-resolver/rocks:/usr/local/etc/rocks:Z"
+      - "log-data:/var/log/dex-backend"
+      - "poolresolver-data:/var/lib/pool-resolver:Z"
     env_file: config.env
     ports:
-      - 9876:9876
+      - "9876:9876"
     depends_on:
-      - kafka1
-      - redis
+      - kafka
+    networks:
+      - spectrum-network
+
+networks:
+  spectrum-network:
+    driver: bridge
+
+volumes:
+  redis-data:
+    driver: local
+  poolresolver-data:
+    driver: local
+  log-data:
+    driver: local
+  zookeeper-data:
+    driver: local
+  zookeeper-datalog:
+    driver: local
+  kafka-data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,9 +39,7 @@ services:
     networks:
       - spectrum-network
   utxo-tracker:
-    build:
-      context: ./modules/utxo-tracker/target/docker/stage
-      dockerfile: Dockerfile
+    image: spectrumlabs/ergo-utxo-tracker:latest
     container_name: utxo-tracker
     volumes:
       - "log-data:/var/log/dex-backend"
@@ -52,9 +50,7 @@ services:
     networks:
       - spectrum-network
   amm-executor:
-    build:
-      context: ./modules/amm-executor/target/docker/stage
-      dockerfile: Dockerfile
+    image: spectrumlabs/ergo-amm-executor:latest
     container_name: amm-executor
     restart: always
     volumes:
@@ -66,9 +62,7 @@ services:
     networks:
       - spectrum-network
   poolresolver:
-    build:
-      context: ./modules/pool-resolver/target/docker/stage
-      dockerfile: Dockerfile
+    image: spectrumlabs/ergo-pool-resolver:latest
     container_name: poolresolver
     volumes:
       - "log-data:/var/log/dex-backend"

--- a/modules/amm-executor/src/main/resources/application.conf
+++ b/modules/amm-executor/src/main/resources/application.conf
@@ -25,7 +25,7 @@ consumers.orders-retry.topic-id = "dex.amm.cfmm.orders.retry"
 producers.orders-retry.topic-id = "dex.amm.cfmm.orders.retry"
 producers.orders-retry.parallelism = 3
 
-kafka.bootstrap-servers = ["kafka1:9092"]
+kafka.bootstrap-servers = ["kafka:9092"]
 
 network.explorer-uri = "https://api.ergoplatform.com"
 network.node-uri = "http://127.0.0.1:9053"

--- a/modules/pool-resolver/src/main/resources/application.conf
+++ b/modules/pool-resolver/src/main/resources/application.conf
@@ -1,7 +1,7 @@
 http.host = "0.0.0.0"
 http.port = 9876
 
-kafka.bootstrap-servers = ["kafka1:9092"]
+kafka.bootstrap-servers = ["kafka:9092"]
 
 consumers.confirmed-amm-pools.group-id = "ergo"
 consumers.confirmed-amm-pools.client-id = "ergo"
@@ -11,4 +11,4 @@ consumers.unconfirmed-amm-pools.group-id = "ergo"
 consumers.unconfirmed-amm-pools.client-id = "ergo"
 consumers.unconfirmed-amm-pools.topic-id = "dex.amm.cfmm.unconfirmed.pools"
 
-rocks.path = "/usr/local/etc/rocks"
+rocks.path = "/var/lib/pool-resolver"

--- a/modules/utxo-tracker/src/main/resources/application.conf
+++ b/modules/utxo-tracker/src/main/resources/application.conf
@@ -13,11 +13,11 @@ producers.unconfirmed-amm-orders.parallelism = 3
 producers.unconfirmed-amm-pools.topic-id = "dex.amm.cfmm.unconfirmed.pools"
 producers.unconfirmed-amm-pools.parallelism = 3
 
-kafka.bootstrap-servers = ["kafka1:9092"]
+kafka.bootstrap-servers = ["kafka:9092"]
 
 protocol.network-type = "mainnet"
 
-ledger-tracking.initial-offset = 9000000
+ledger-tracking.initial-offset = 27000000
 ledger-tracking.batch-size = 500
 ledger-tracking.retry-delay = 5s
 

--- a/run
+++ b/run
@@ -1,2 +1,0 @@
-export DEX_SOURCES_PATH=${PWD}
-sudo -E docker-compose up -d

--- a/run.ps1
+++ b/run.ps1
@@ -1,2 +1,0 @@
-$env:DEX_SOURCES_PATH=$PSScriptRoot
-docker compose up -d


### PR DESCRIPTION
Discussed with @GusevTimofey a new improved docker setup to reduce setup issues user have especially under Windows environments. 

This pull request adds an GitHub Action to build and release docker images for the off-chain bots on Docker Hub so users don't have to build the images themself and can pull/update directly from Docker Hub. For this to work you have to configure Docker Hub credentials in the repository secrets. The action expects these secrets:
```
${{ secrets.DOCKER_USERNAME }}
${{ secrets.DOCKER_PASSWORD }}
```
Also the current configuration is set to publish the images under the Docker Hub Username: `spectrum-finance` if this doesn't exist you would need to create it or if an account already exists than you have to change the tags in `.github/workflows/publish-docker-images.yml` accordingly.